### PR TITLE
Adding unusable reference files

### DIFF
--- a/common/api.yaml
+++ b/common/api.yaml
@@ -1,0 +1,6 @@
+---
+# This file is here for reference and cannot be used as a package because of !secret
+api:
+  encryption:
+    key: !secret encryption_key
+

--- a/common/ota.yaml
+++ b/common/ota.yaml
@@ -1,0 +1,5 @@
+---
+# This file is here for reference and cannot be used as a package because of !secret
+ota:
+  password: !secret ota_pass
+

--- a/common/wifi.yaml
+++ b/common/wifi.yaml
@@ -1,0 +1,12 @@
+---
+# This file is here for reference and cannot be used as a package because of !secret 
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_pass
+  domain: ${wifi_domain}
+  fast_connect: on
+  use_address: $ipaddr
+
+  ap:
+    ssid: AP_${devicename}
+


### PR DESCRIPTION
These files cannot be used as remote packages due to use of `!secret`, but are included here for reference