### PR TITLE
Refine the IR templates

### DIFF
--- a/template/ir_blaster.yaml
+++ b/template/ir_blaster.yaml
@@ -7,13 +7,12 @@
 <<: !include
   file: ../esphome.yaml
   vars:
-    project_name: untergeek.ir_blaster
+    project_name: untergeek.esp8266_ir_blaster
     project_version: 1.0.0
 <<: !include ../time.yaml
 <<: !include ../restart_switch.yaml
 <<: !include ../noseriallog.yaml
 
-remote_transmitter:
-  pin: ${ir_tx_pin}
-  carrier_duty_percent: 50%
+# You need to include at least one of ir_tx.yaml or ir_rx.yaml, or build your own
+# remote_transmitter / remote_receiver blocks
 

--- a/template/ir_rx.yaml
+++ b/template/ir_rx.yaml
@@ -1,0 +1,28 @@
+---
+### For ESP8266 based blaster units -- including ESP12-E analogs like the Tuya CB3S --
+### the GPIOs all seem to be the same
+
+# Button  : GPIO13
+# IR RX   : GPIO5
+# WiFi LED: GPIO4
+# IR TX   : GPIO14
+
+remote_receiver:
+  id: ir_rx
+  pin:
+    number: GPIO5
+    inverted: true
+
+### EXTENDING
+
+# If any value needs changing, use the !extend functionality:
+
+# remote_receiver:
+#   - id: !extend ir_rx
+#     pin:
+#       number: # Other GPIO
+#       inverted: # True or False
+#     dump: # all, or a list of individual codes 
+
+# See https://esphome.io/components/remote_receiver.html?highlight=remote_receiver#configuration-variables
+

--- a/template/ir_tx.yaml
+++ b/template/ir_tx.yaml
@@ -1,0 +1,26 @@
+---
+### For ESP8266 based blasters -- including ESP12-E analogs like the Tuya CB3S --
+### the GPIOs all seem to be the same
+
+# Button  : GPIO13
+# IR RX   : GPIO5
+# WiFi LED: GPIO4
+# IR TX   : GPIO14
+
+remote_transmitter:
+  id: ir_tx
+  pin: GPIO14
+  carrier_duty_percent: 50%
+
+### EXTENDING
+
+# If any value needs changing, use the !extend functionality:
+
+# remote_transmitter:
+#   - id: !extend ir_tx
+#     pin: # Other GPIO
+#     carrier_duty_percent: # Other percentage
+#     # Other settings and values?
+
+# See https://esphome.io/components/remote_transmitter.html
+


### PR DESCRIPTION
- `ir_blaster.yaml` contains the base esp8266 template 
- `ir_tx.yaml` is if you want to enable transmitter functionality (most likely) 
- `ir_rx.yaml` is if you want to enable receiver functionality