### PR TITLE
Trying to use packages instead of straight includes

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,5 +1,6 @@
 ---
-<<: !include esphome.yaml
-<<: !include time.yaml
-<<: !include logging.yaml
+packages:
+  esphome: !include esphome.yaml
+  time: !include time.yaml
+  logging: !include logging.yaml
 

--- a/esp8266.yaml
+++ b/esp8266.yaml
@@ -1,4 +1,8 @@
 ---
+defaults:
+  restore: false
+ 
 esp8266:
   board: ${board}
-
+  restore_from_flash: ${restore}
+   

--- a/template/bpa800-rgbw-ag-2.yaml
+++ b/template/bpa800-rgbw-ag-2.yaml
@@ -1,12 +1,17 @@
 ---
-<<: !include
-  file: ../esphome.yaml
-  vars:
-    project_name: untergeek.bpa800-rgb2-ag-2
-    project_version: 1.2.0
-<<: !include ../time.yaml
-<<: !include ../noseriallog.yaml
-<<: !include { file: ../esp8266.yaml, vars: { board: esp01_1m } }
+packages:
+  main: !include
+    file: ../esphome.yaml
+    vars:
+      project_name: untergeek.bpa800-rgb2-ag-2
+      project_version: 1.2.0
+  chip: !include
+    file: ../esp8266.yaml
+    vars:
+      board: esp01_1m
+  sync: !include ../time.yaml
+  togl: !include ../restart_switch.yaml
+  logs: !include ../logging.yaml
 
 defaults:
   cold: 6500 K

--- a/template/bpa800-rgbw-ag-2p.yaml
+++ b/template/bpa800-rgbw-ag-2p.yaml
@@ -1,12 +1,17 @@
 ---
-<<: !include 
-  file: ../esphome.yaml
-  vars: 
-    project_name: untergeek.bpa800-rgb2-ag-2p
-    project_version: 1.2.0
-<<: !include ../time.yaml
-<<: !include ../noseriallog.yaml
-<<: !include { file: ../esp8266.yaml, vars: { board: esp01_1m } }
+packages:
+  main: !include
+    file: ../esphome.yaml
+    vars:
+      project_name: untergeek.bpa800-rgb2-ag-2p
+      project_version: 1.2.0
+  chip: !include
+    file: ../esp8266.yaml
+    vars:
+      board: esp01_1m
+  sync: !include ../time.yaml
+  togl: !include ../restart_switch.yaml
+  logs: !include ../logging.yaml
 
 defaults:
   cold: 6500 K

--- a/template/bpdim.yaml
+++ b/template/bpdim.yaml
@@ -1,18 +1,18 @@
 ---
 # We track the project name and version here in the template
-<<: !include
-  file: ../esphome.yaml
-  vars:
-    project_name: untergeek.bpdim
-    project_version: 1.1.0
-
-<<: !include
-  file: ../esp8266.yaml
-  vars:
-    board: esp01_1m
-<<: !include ../time.yaml
-<<: !include ../restart_switch.yaml
-<<: !include ../noseriallog.yaml
+packages:
+  main: !include
+    file: ../esphome.yaml
+    vars:
+      project_name: untergeek.bpdim
+      project_version: 1.1.0
+  chip: !include
+    file: ../esp8266.yaml
+    vars:
+      board: esp01_1m
+  sync: !include ../time.yaml
+  togl: !include ../restart_switch.yaml
+  logs: !include ../logging.yaml
 
 defaults:
   tuya_id: dimmer

--- a/template/ir_blaster.yaml
+++ b/template/ir_blaster.yaml
@@ -2,16 +2,17 @@
 ### For the ir_blaster template:
 ### Under substitutions, 
 ### You must manually add board: esp01_1m or board: esp12e
-<<: !include ../esp8266.yaml
 
-<<: !include
-  file: ../esphome.yaml
-  vars:
-    project_name: untergeek.esp8266_ir_blaster
-    project_version: 1.0.0
-<<: !include ../time.yaml
-<<: !include ../restart_switch.yaml
-<<: !include ../noseriallog.yaml
+packages:
+  main: !include
+    file: ../esphome.yaml
+    vars:
+      project_name: untergeek.esp8266_ir_blaster
+      project_version: 1.0.0
+  chip: !include ../esp8266.yaml
+  sync: !include ../time.yaml
+  togl: !include ../restart_switch.yaml
+  logs: !include ../logging.yaml
 
 # You need to include at least one of ir_tx.yaml or ir_rx.yaml, or build your own
 # remote_transmitter / remote_receiver blocks


### PR DESCRIPTION
The `<<: !include...` syntax is great in YAML, but ESPHome only recognizes the `defaults:` block if it's brought in as a `package`, which may be why my `esp8266.yaml` failed to work last time.

Testing again...