### PR TITLE
Substitute substitutions for defaults

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   api_secret: NOT_CONFIGURED
 
 api:

--- a/esp32.yaml
+++ b/esp32.yaml
@@ -1,5 +1,9 @@
 ---
+substitutions:
+  framework: arduino
+
 esp32:
   board: ${board}
   framework:
     type: ${framework}
+

--- a/esp8266.yaml
+++ b/esp8266.yaml
@@ -1,4 +1,8 @@
 ---
+substitutions:
+  restore: "false"
+
 esp8266:
   board: ${board}
+  restore_from_flash: "${restore}"  
 

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -1,3 +1,4 @@
+---
 esphome:
   name: ${devicename}
   friendly_name: "${friendly_name}"

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   log_baud: 0
   log_level: DEBUG
 

--- a/ota.yaml
+++ b/ota.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   ota_pass: NOT_CONFIGURED
 
 ota:

--- a/restart_switch.yaml
+++ b/restart_switch.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   restart_sw_id: restart_device
 
 switch:

--- a/restart_switch.yaml
+++ b/restart_switch.yaml
@@ -1,9 +1,9 @@
 ---
 substitutions:
-  restart_sw_id: restart_device
+  rds: r_sw
 
 switch:
   - platform: restart
     name: "Restart '${friendly_name}'"
-    id: ${restart_sw_id}
+    id: ${rds}
 

--- a/template/bpa800-rgbw-ag-2.yaml
+++ b/template/bpa800-rgbw-ag-2.yaml
@@ -13,15 +13,15 @@ packages:
   togl: !include ../restart_switch.yaml
   logs: !include ../logging.yaml
 
-defaults:
+substitutions:
   cold: 6500 K
   warm: 2700 K
   gamma: 0.0
   restore_mode: RESTORE_DEFAULT_OFF
 
-### Change from defaults
+### Change from defaults in substitutions
 
-# If any value needs changing, use package import
+# If any value needs changing, use top-level substitutions in your main config, or package import
 
 #packages:
 #  remote: !include

--- a/template/bpa800-rgbw-ag-2p.yaml
+++ b/template/bpa800-rgbw-ag-2p.yaml
@@ -13,15 +13,15 @@ packages:
   togl: !include ../restart_switch.yaml
   logs: !include ../logging.yaml
 
-defaults:
+substitutions:
   cold: 6500 K
   warm: 2700 K
   gamma: 0.0
   restore_mode: RESTORE_DEFAULT_OFF
 
-### Change from defaults
+### Change from defaults in substitutions
 
-# If any value needs changing, use package import
+# If any value needs changing, use substitutions in the main configuration file, or package import
 
 #packages:
 #  remote: !include

--- a/template/bpdim.yaml
+++ b/template/bpdim.yaml
@@ -14,7 +14,7 @@ packages:
   togl: !include ../restart_switch.yaml
   logs: !include ../logging.yaml
 
-defaults:
+substitutions:
   tuya_id: dimmer
   icon: "mdi:light-switch"
   min: 10
@@ -23,9 +23,9 @@ defaults:
   tx_pin: GPIO1
   baud: 9600
 
-### Change from default values
+### Change from default values in substitutions
 
-# If any value needs changing from these defaults, use vars during package import
+# If any value needs changing, set substitutions in the main configuration file, or use vars during package import
 
 #packages:
 #  remote: !include

--- a/template/ir_rx.yaml
+++ b/template/ir_rx.yaml
@@ -2,7 +2,7 @@
 ### For ESP8266 based blaster units -- including ESP12-E analogs like the Tuya CB3S --
 ### the GPIOs all seem to be the same
 
-defaults:
+substitutions:
   button_pin: GPIO13
   ir_rx_pin: GPIO5
   wifi_led_pin: GPIO4
@@ -15,9 +15,9 @@ remote_receiver:
     number: ${ir_rx_pin}
     inverted: ${inverted}
 
-### Change from defaults
+### Change from default values in substitutions
 
-# If any value needs changing from these defaults, use package import
+# If any value needs changing, use substitutions in the main configuration file, or use package import
 
 #packages:
 #  remote: !include

--- a/template/ir_tx.yaml
+++ b/template/ir_tx.yaml
@@ -2,7 +2,7 @@
 ### For ESP8266 based blasters -- including ESP12-E analogs like the Tuya CB3S --
 ### the GPIOs all seem to be the same
 
-defaults:
+substitutions:
   button_pin: GPIO13
   ir_rx_pin: GPIO5
   wifi_led_pin: GPIO4
@@ -14,9 +14,9 @@ remote_transmitter:
   pin: ${ir_tx_pin}
   carrier_duty_percent: ${duty_pct}
 
-### Change from defaults
+### Change from default values in substitutions
 
-# If any value needs changing, use package import 
+# If any value needs changing, set substitutions in the main configuration file, or use package import 
 
 #packages:
 #  remote: !include

--- a/template/pronto_tx.yaml
+++ b/template/pronto_tx.yaml
@@ -2,7 +2,7 @@
 # This is more for an example than for use. The reason is that 
 # remote_transmitter.transmit_pronto has to be part of an action, rather than a stand-alone template
 
-defaults:
+substitutions:
   data: '0000 006D 0000 0000' # This is a signal preamble indicating no code will be sent
   times: 3
   wait_time: 0ms

--- a/time.yaml
+++ b/time.yaml
@@ -1,8 +1,8 @@
 ---
 substitutions:
-  hass_time_id: homeassistant_time
+  time_id: ha_time
 
 time:
   - platform: homeassistant
-    id: ${hass_time_id}
+    id: ${time_id}
 

--- a/time.yaml
+++ b/time.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   hass_time_id: homeassistant_time
 
 time:

--- a/wifi.yaml
+++ b/wifi.yaml
@@ -1,5 +1,5 @@
 ---
-defaults:
+substitutions:
   wifi_ssid: NOT_CONFIGURED
   wifi_pass: NOT_CONFIGURED
   wifi_domain: example.org


### PR DESCRIPTION
The documentation may be outdated. It appears that substitutions are the way to go, and defaults can be overridden with vars or top-level substitutions.