### PR TITLE
Add hostname as a substitution for name directive

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  name: ${devicename}
+  name: ${hostname}
   friendly_name: "${friendly_name}"
   comment: "${comment}"
   area: ${area}


### PR DESCRIPTION
It's been YEARS and I barely realized this is why my devicenames with underscores were causing me grief.