### PR TITLE
Icon selection missing from light

### DIFF
--- a/template/mjsd01.yaml
+++ b/template/mjsd01.yaml
@@ -66,6 +66,7 @@ light:
   - platform: monochromatic
     # https://esphome.io/components/light/monochromatic.html
     name: ${devicename}
+    icon: ${icon}
     output: pwm
     default_transition_length: ${no_delay}
     id: dimmer


### PR DESCRIPTION
`icon` is in `substitutions` but not assigned (until now).